### PR TITLE
Add pixi-viewport

### DIFF
--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"ecsy": "^0.4.0",
+		"pixi-viewport": "^4.13.2",
 		"pixi.js": "^5.3.3",
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1"

--- a/packages/webapp/scripts/build.js
+++ b/packages/webapp/scripts/build.js
@@ -100,6 +100,8 @@ async function developmentBuild() {
 					? 'ecsy/build/ecsy.module.js'
 					: name === 'pixi.js'
 					? 'pixi.js/lib/pixi.es.js'
+					: name === 'pixi-viewport'
+					? 'pixi-viewport/dist/viewport.es.js'
 					: name
 			)
 

--- a/packages/webapp/source/components/Game/Engine/Benchmark.ts
+++ b/packages/webapp/source/components/Game/Engine/Benchmark.ts
@@ -51,7 +51,7 @@ export function randomColor(): number {
 }
 
 export function randomCoord(): number {
-	return Math.round(Math.random() * 50)
+	return Math.round(Math.random() * 80 - 40)
 }
 
 export function randomHop(): object {

--- a/packages/webapp/source/components/Game/Engine/systems/SpriteSystem.ts
+++ b/packages/webapp/source/components/Game/Engine/systems/SpriteSystem.ts
@@ -6,9 +6,11 @@ import * as PIXI from 'pixi.js'
 export default class SpriteSystem extends System {
 	private resources: any
 	private renderer: any
+	private view: any
 	init(attributes: Attributes) {
 		this.resources = attributes.resources
 		this.renderer = attributes.renderer
+		this.view = this.renderer.view
 	}
 	execute(_delta: number, _time: number) {
 		let updated = this.queries.updated.changed!
@@ -29,7 +31,7 @@ export default class SpriteSystem extends System {
 			let pixiSprite = new PIXI.Sprite(this.resources.textures[sprite.sheet])
 			pixiSprite.setTransform(sprite.x, sprite.y)
 			pixiSprite.zIndex = sprite.zIndex
-			this.renderer.app.stage.addChild(pixiSprite)
+			this.view.addChild(pixiSprite)
 			entity.addComponent(PixiSprite, { value: pixiSprite })
 		}
 
@@ -37,7 +39,7 @@ export default class SpriteSystem extends System {
 		for (let i = removed.length - 1; i >= 0; i--) {
 			let entity = removed[i]
 			let pixiSprite = entity.getComponent!(PixiSprite)
-			this.renderer.app.stage.removeChild(pixiSprite.value)
+			this.view.removeChild(pixiSprite.value)
 			pixiSprite.value.destroy()
 			entity.removeComponent(PixiSprite)
 		}

--- a/packages/webapp/source/components/Game/Renderer/Renderer.ts
+++ b/packages/webapp/source/components/Game/Renderer/Renderer.ts
@@ -1,4 +1,5 @@
 import * as PIXI from 'pixi.js'
+import { Viewport } from 'pixi-viewport'
 
 // Global PIXI settings
 PIXI.settings.RESOLUTION = window.devicePixelRatio
@@ -6,6 +7,7 @@ PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST
 
 export default class Renderer {
 	app: PIXI.Application
+	view: Viewport
 	constructor(canvas: HTMLCanvasElement) {
 		this.app = new PIXI.Application({
 			width: 800,
@@ -13,7 +15,16 @@ export default class Renderer {
 			backgroundColor: 0x1d171f,
 			view: canvas,
 		})
+		this.view = new Viewport({
+			screenWidth: window.innerWidth,
+			screenHeight: window.innerHeight,
+			worldWidth: 800,
+			worldHeight: 600,
+			interaction: this.app.renderer.plugins.interaction,
+		})
+		this.app.stage.addChild(this.view)
+		this.view.drag().pinch().wheel().decelerate()
 		this.app.stage.sortableChildren = true
-		this.app.stage.setTransform(this.app.view.width / 2, 0) // Center on 0, 0
+		// this.app.stage.setTransform(this.app.view.width / 2, 0) // Center on 0, 0
 	}
 }

--- a/packages/webapp/source/components/Game/Renderer/Renderer.ts
+++ b/packages/webapp/source/components/Game/Renderer/Renderer.ts
@@ -10,20 +10,18 @@ export default class Renderer {
 	view: Viewport
 	constructor(canvas: HTMLCanvasElement) {
 		this.app = new PIXI.Application({
-			width: 800,
-			height: 600,
 			backgroundColor: 0x1d171f,
 			view: canvas,
+			resolution: 1,
 		})
 		this.view = new Viewport({
-			screenWidth: window.innerWidth,
-			screenHeight: window.innerHeight,
-			worldWidth: 800,
-			worldHeight: 600,
+			screenWidth: this.app.view.offsetWidth,
+			screenHeight: this.app.view.offsetHeight,
 			interaction: this.app.renderer.plugins.interaction,
 		})
-		this.app.stage.addChild(this.view)
 		this.view.drag().pinch().wheel().decelerate()
+		this.view.moveCenter(0, 0)
+		this.app.stage.addChild(this.view)
 		this.app.stage.sortableChildren = true
 		// this.app.stage.setTransform(this.app.view.width / 2, 0) // Center on 0, 0
 	}

--- a/packages/webapp/source/components/Game/Renderer/Renderer.ts
+++ b/packages/webapp/source/components/Game/Renderer/Renderer.ts
@@ -20,7 +20,7 @@ export default class Renderer {
 		})
 		this.view.drag().pinch().wheel().decelerate()
 		this.view.moveCenter(0, 0)
+		this.view.sortableChildren = true
 		this.app.stage.addChild(this.view)
-		this.app.stage.sortableChildren = true
 	}
 }

--- a/packages/webapp/source/components/Game/Renderer/Renderer.ts
+++ b/packages/webapp/source/components/Game/Renderer/Renderer.ts
@@ -22,6 +22,5 @@ export default class Renderer {
 		this.view.moveCenter(0, 0)
 		this.app.stage.addChild(this.view)
 		this.app.stage.sortableChildren = true
-		// this.app.stage.setTransform(this.app.view.width / 2, 0) // Center on 0, 0
 	}
 }

--- a/packages/webapp/source/components/Game/Renderer/Renderer.ts
+++ b/packages/webapp/source/components/Game/Renderer/Renderer.ts
@@ -2,7 +2,7 @@ import * as PIXI from 'pixi.js'
 import { Viewport } from 'pixi-viewport'
 
 // Global PIXI settings
-PIXI.settings.RESOLUTION = window.devicePixelRatio
+PIXI.settings.RESOLUTION = 1
 PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST
 
 export default class Renderer {
@@ -12,7 +12,6 @@ export default class Renderer {
 		this.app = new PIXI.Application({
 			backgroundColor: 0x1d171f,
 			view: canvas,
-			resolution: 1,
 		})
 		this.view = new Viewport({
 			screenWidth: this.app.view.offsetWidth,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4620,6 +4620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"penner@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "penner@npm:0.1.3"
+  checksum: 98f2588e6785bcb18d421b80f64f93b8626db1f02702d2597a4074280019996cb8360d673c1eee88de8192c79428a86e61e117b9435a05d441ee56760ed4c18b
+  languageName: node
+  linkType: hard
+
 "performance-now@npm:^2.1.0":
   version: 2.1.0
   resolution: "performance-now@npm:2.1.0"
@@ -4640,6 +4647,17 @@ __metadata:
   dependencies:
     node-modules-regexp: ^1.0.0
   checksum: 21604008c36ab6e14ac458e1a267dd7322cfd36b9e1042e9e277dd064582717e30b9aba8c0a47d738bf004ee7946ed27f6b982d30968534f2c6b5b168a52b555
+  languageName: node
+  linkType: hard
+
+"pixi-viewport@npm:^4.13.2":
+  version: 4.13.2
+  resolution: "pixi-viewport@npm:4.13.2"
+  dependencies:
+    penner: ^0.1.3
+  peerDependencies:
+    pixi.js: ">=4.6.0"
+  checksum: 68224eb887c20a7d0889eb02ac76e2caa474f85070b429369ad4f41b7a453ffd737800e8b86467484164aefb62b7f9d9bb07a7578aebdd39295336f4fa73485a
   languageName: node
   linkType: hard
 
@@ -6057,6 +6075,7 @@ typescript@^3.9.7:
     "@types/yargs-parser": ^15.0.0
     ecsy: ^0.4.0
     jest: ^26.4.0
+    pixi-viewport: ^4.13.2
     pixi.js: ^5.3.3
     prettier: ^2.0.5
     react: ^16.13.1


### PR DESCRIPTION
Implementing the very handy [pixi-viewport](https://github.com/davidfig/pixi-viewport) plugin.

This allows panning and zooming the view on both desktop and mobile.

The resolution inconsistency was also fixed on mobile.