### PR TITLE
Map system 🗺

### DIFF
--- a/packages/webapp/source/components/Game/Common/Map.ts
+++ b/packages/webapp/source/components/Game/Common/Map.ts
@@ -1,0 +1,15 @@
+export class Map3D {
+	private data: Map<string, any>
+	constructor() {
+		this.data = new Map()
+	}
+	getXYZ(x: number, y: number, z: number) {
+		return this.data.get(Map3D.xyzToHash(x, y, z))
+	}
+	setXYZ(x: number, y: number, z: number, value: any): void {
+		this.data.set(Map3D.xyzToHash(x, y, z), value)
+	}
+	private static xyzToHash(x: number, y: number, z: number): string {
+		return x + ':' + y + ':' + z
+	}
+}

--- a/packages/webapp/source/components/Game/Common/Map.ts
+++ b/packages/webapp/source/components/Game/Common/Map.ts
@@ -1,15 +1,48 @@
+import { Entity } from 'ecsy'
+
 export class Map3D {
-	private data: Map<string, any>
+	private data: Map<string, Cell3D>
 	constructor() {
 		this.data = new Map()
 	}
-	getXYZ(x: number, y: number, z: number) {
+	getXYZ(x: number, y: number, z: number): Cell3D | undefined {
 		return this.data.get(Map3D.xyzToHash(x, y, z))
 	}
-	setXYZ(x: number, y: number, z: number, value: any): void {
-		this.data.set(Map3D.xyzToHash(x, y, z), value)
+	addCell(cell: Cell3D): void {
+		// Throw if occupied?
+		this.data.set(cell.getHash(), cell)
+	}
+	clearXYZ(x: number, y: number, z: number): void {
+		this.data.delete(Map3D.xyzToHash(x, y, z))
 	}
 	private static xyzToHash(x: number, y: number, z: number): string {
 		return x + ':' + y + ':' + z
+	}
+}
+export class Cell3D {
+	private map: Map3D
+	private x: number
+	private y: number
+	private z: number
+	entity: Entity
+	constructor(map: Map3D, x: number, y: number, z: number, entity: Entity) {
+		this.map = map
+		this.x = x
+		this.y = y
+		this.z = z
+		this.entity = entity
+	}
+	getHash(): string {
+		return this.x + ':' + this.y + ':' + this.z
+	}
+	moveTo(x: number, y: number, z: number): void {
+		this.map.clearXYZ(this.x, this.y, this.z)
+		this.x = x
+		this.y = y
+		this.z = z
+		this.map.addCell(this)
+	}
+	destroy(): void {
+		this.map.clearXYZ(this.x, this.y, this.z)
 	}
 }

--- a/packages/webapp/source/components/Game/Common/Map.ts
+++ b/packages/webapp/source/components/Game/Common/Map.ts
@@ -9,7 +9,6 @@ export class Map3D {
 		return this.data.get(Map3D.xyzToHash(x, y, z))
 	}
 	addCell(cell: Cell3D): void {
-		// Throw if occupied?
 		this.data.set(cell.getHash(), cell)
 	}
 	clearXYZ(x: number, y: number, z: number): void {
@@ -20,17 +19,26 @@ export class Map3D {
 	}
 }
 export class Cell3D {
-	private map: Map3D
+	private readonly map: Map3D
 	private x: number
 	private y: number
 	private z: number
-	entity: Entity
-	constructor(map: Map3D, x: number, y: number, z: number, entity: Entity) {
+	entity?: Entity
+	parentCell?: Cell3D
+	constructor(
+		map: Map3D,
+		x: number,
+		y: number,
+		z: number,
+		entity?: Entity,
+		parentCell?: Cell3D
+	) {
 		this.map = map
 		this.x = x
 		this.y = y
 		this.z = z
-		this.entity = entity
+		if (entity) this.entity = entity
+		if (parentCell) this.parentCell = parentCell
 	}
 	getHash(): string {
 		return this.x + ':' + this.y + ':' + this.z
@@ -41,6 +49,14 @@ export class Cell3D {
 		this.y = y
 		this.z = z
 		this.map.addCell(this)
+	}
+	getNeighbor(x: number, y: number, z: number): Cell3D | undefined {
+		return this.map.getXYZ(this.x + x, this.y + y, this.z + z)
+	}
+	spread(x: number, y: number, z: number): void {
+		this.map.addCell(
+			new Cell3D(this.map, this.x + x, this.y + y, this.z + z, undefined, this)
+		)
 	}
 	destroy(): void {
 		this.map.clearXYZ(this.x, this.y, this.z)

--- a/packages/webapp/source/components/Game/Engine/Benchmark.ts
+++ b/packages/webapp/source/components/Game/Engine/Benchmark.ts
@@ -3,13 +3,25 @@ import Transform from './components/Transform'
 import Sprite from './components/Sprite'
 import Actor from './components/Actor'
 import Hop from './components/Hop'
+import MapCell from './components/MapCell'
+
+interface Grid {
+	x: number
+	y: number
+	z: number
+}
 
 export function addActors(world: World, count: number): Entity[] {
 	let entities: Entity[] = []
+	let gridPool = createGridPool(30, 30, 1)
 	for (let i = 0; i < count; i++) {
+		let grid = gridPool.splice(
+			Math.floor(Math.random() * gridPool.length),
+			1
+		)[0]
 		let actorEntity = world
 			.createEntity()
-			.addComponent(Transform, { x: randomCoord(), y: randomCoord(), z: 0 })
+			.addComponent(Transform, grid)
 			.addComponent(Sprite, { texture: 'cube:0' })
 			.addComponent(Actor, {
 				userID: randomString([48, 57], 18),
@@ -45,23 +57,41 @@ export function randomColor(): number {
 	return COLORS[Math.floor(Math.random() * COLORS.length)]
 }
 
-export function randomCoord(): number {
-	return Math.round(Math.random() * 30 - 15)
+export function createGridPool(
+	xSize: number,
+	ySize: number,
+	zSize: number
+): Grid[] {
+	let pool: Grid[] = []
+	for (let x = 0; x < xSize; x++) {
+		for (let y = 0; y < ySize; y++) {
+			for (let z = 0; z < zSize; z++) {
+				pool.push({
+					x: x - Math.floor(xSize / 2),
+					y: y - Math.floor(ySize / 2),
+					z: z - Math.floor(zSize / 2),
+				})
+			}
+		}
+	}
+	return pool
 }
 
 const directions = {
-	east: { x: 1, direction: 'east' },
-	west: { x: -1, direction: 'west' },
-	south: { y: 1, direction: 'south' },
-	north: { y: -1, direction: 'north' },
+	east: { x: 1, y: 0, direction: 'east' },
+	west: { x: -1, y: 0, direction: 'west' },
+	south: { y: 1, x: 0, direction: 'south' },
+	north: { y: -1, x: 0, direction: 'north' },
 }
 
 export function hopActor(actor: Entity, direction?: keyof typeof directions) {
-	if (!actor.hasComponent(Hop))
-		actor.addComponent(
-			Hop,
-			directions[direction as keyof typeof directions] || randomHop()
-		)
+	if (actor.hasComponent(Hop)) return
+	let hop = directions[direction as keyof typeof directions] || randomHop()
+	let { value: mapCell } = actor.getComponent(MapCell)!
+	if (!mapCell.getNeighbor(hop.x || 0, hop.y || 0, 0)) {
+		mapCell.spread(hop.x || 0, hop.y || 0, 0)
+		actor.addComponent(Hop, hop)
+	}
 }
 
 export function randomHop(): object {

--- a/packages/webapp/source/components/Game/Engine/components/MapCell.ts
+++ b/packages/webapp/source/components/Game/Engine/components/MapCell.ts
@@ -1,0 +1,10 @@
+import { Component, Types } from 'ecsy'
+import { Cell3D } from '../../Common/Map'
+
+export default class MapCell extends Component<MapCell> {
+	value!: Cell3D
+}
+
+MapCell.schema = {
+	value: { type: Types.Ref },
+}

--- a/packages/webapp/source/components/Game/Engine/systems/HopSystem.ts
+++ b/packages/webapp/source/components/Game/Engine/systems/HopSystem.ts
@@ -28,7 +28,7 @@ export default class HopSystem extends System {
 				else sprite.texture = 'cube:2'
 				entity.removeComponent(Hop)
 				return
-			} else if (frame === 0 || frame > hop.frame) {
+			} else if (hop.progress === 0 || frame > hop.frame) {
 				hop.frame = frame
 				let sprite = entity.getMutableComponent(Sprite)!
 				sprite.texture = this.animations[`hop-${hop.direction}`][

--- a/packages/webapp/source/components/Game/Engine/systems/MapSystem.ts
+++ b/packages/webapp/source/components/Game/Engine/systems/MapSystem.ts
@@ -1,0 +1,41 @@
+import { Attributes, Not, System } from 'ecsy'
+import { Cell3D } from '../../Common/Map'
+import Transform from '../components/Transform'
+import MapCell from '../components/MapCell'
+export default class MapSystem extends System {
+	private map: any
+	init(attributes: Attributes) {
+		this.map = attributes.map
+	}
+
+	execute(_delta: number, _time: number) {
+		this.queries.added.results.forEach((entity) => {
+			let { x, y, z } = entity.getComponent(Transform)!
+			let cell = new Cell3D(this.map, x, y, z, entity)
+			entity.addComponent(MapCell, { value: cell })
+			this.map.addCell(cell)
+		})
+		this.queries.moving.changed!.forEach((entity) => {
+			let { x, y, z } = entity.getComponent(Transform)!
+			entity.getComponent(MapCell)!.value.moveTo(x, y, z)
+		})
+		let removed = this.queries.removed.results
+		for (let i = removed.length - 1; i >= 0; i--) {
+			let entity = removed[i]
+			entity.getComponent(MapCell)!.value.destroy()
+			entity.removeComponent(MapCell)
+		}
+	}
+}
+MapSystem.queries = {
+	added: {
+		components: [Transform, Not(MapCell)],
+	},
+	moving: {
+		components: [Transform, MapCell],
+		listen: { changed: [Transform] },
+	},
+	removed: {
+		components: [Not(Transform), MapCell],
+	},
+}

--- a/packages/webapp/source/components/Game/Game.ts
+++ b/packages/webapp/source/components/Game/Game.ts
@@ -1,15 +1,18 @@
 import Renderer from './Renderer/Renderer'
 import Resources from './Renderer/Resources/Resources'
 import Engine from './Engine/Engine'
+import { Map3D } from './Common/Map'
 import { addActors, hopActor } from './Engine/Benchmark'
 import Sprite from './Engine/components/Sprite'
 import PixiSprite from './Engine/components/PixiSprite'
 import Transform from './Engine/components/Transform'
 import Actor from './Engine/components/Actor'
 import Hop from './Engine/components/Hop'
+import MapCell from './Engine/components/MapCell'
+import HopSystem from './Engine/systems/HopSystem'
+import MapSystem from './Engine/systems/MapSystem'
 import TransformSystem from './Engine/systems/TransformSystem'
 import SpriteSystem from './Engine/systems/SpriteSystem'
-import HopSystem from './Engine/systems/HopSystem'
 
 export async function initGame(canvas: HTMLCanvasElement) {
 	const renderer: Renderer = new Renderer(canvas)
@@ -17,12 +20,15 @@ export async function initGame(canvas: HTMLCanvasElement) {
 	const resources = new Resources()
 	await resources.load()
 	const engine: Engine = new Engine()
+	const map: Map3D = new Map3D()
 	engine.world.registerComponent(Sprite)
 	engine.world.registerComponent(Transform)
 	engine.world.registerComponent(Actor)
 	engine.world.registerComponent(Hop)
+	engine.world.registerComponent(MapCell)
 	engine.world.registerComponent(PixiSprite, false) // Do not pool
 	engine.world.registerSystem(HopSystem, { resources })
+	engine.world.registerSystem(MapSystem, { map })
 	engine.world.registerSystem(TransformSystem)
 	engine.world.registerSystem(SpriteSystem, { resources, renderer })
 	console.log('ECSY world initialized!', engine.world)

--- a/packages/webapp/source/components/Game/Game.ts
+++ b/packages/webapp/source/components/Game/Game.ts
@@ -25,7 +25,7 @@ export async function initGame(canvas: HTMLCanvasElement) {
 	engine.world.registerComponent(Transform)
 	engine.world.registerComponent(Actor)
 	engine.world.registerComponent(Hop)
-	engine.world.registerComponent(MapCell)
+	engine.world.registerComponent(MapCell, false) // Do not pool
 	engine.world.registerComponent(PixiSprite, false) // Do not pool
 	engine.world.registerSystem(HopSystem, { resources })
 	engine.world.registerSystem(MapSystem, { map })


### PR DESCRIPTION
Add a 3D grid map class and system, as well as collision checking for actors.

The `Map3D` class contains a hashmap data structure where the hashes are `x:y:z` coordinates (e.g. `5:0:-2`) and the values are instances of the `Cell3D` class.

The `MapSystem` handles the creating and updating of `MapCell` components for entities that have `Transform` components. The `MapCell` simply contains a reference to the `Cell3D` (similar to the sprite system with PIXI sprites)

Collision checking for hopping is performed with helpful methods of `Cell3D`:
- `getNeighbor(x,y,z)` checks the map with coordinates relative to the cell (so we can use the hop direction `x` and `y` as input)
- `spread(x,y,z)` creates a placeholder cell at the coordinates relative to the cell (so we can reserve the spot being hopped to)

The placeholder cell created when hopping is overwritten with the actor cell when the hop is complete. This effectively deletes the placeholder since it is no longer referenced by anything. The map itself does not check or care about writing cells to occupied coordinates, since anything using the map can perform such checks on its own.