### PR TITLE
Hopping improvements 🦘

### DIFF
--- a/packages/webapp/source/art/sprite-config.json
+++ b/packages/webapp/source/art/sprite-config.json
@@ -1,88 +1,97 @@
 {
-	"cube": {
-		"w": 14,
-		"h": 14
-	},
-	"cube-idle": {
-		"w": 14,
-		"h": 14
-	},
-	"cube-off": {
-		"w": 14,
-		"h": 14
-	},
-	"talk-right": {
-		"w": 14,
-		"h": 14,
-		"animation": true
-	},
-	"talk-left": {
-		"w": 14,
-		"h": 14,
-		"animation": true
-	},
-	"hop-west": {
-		"w": 35,
-		"h": 27,
-		"anchor": {
-			"x": 19,
-			"y": 11
+	"frames": {
+		"cube": {
+			"w": 14,
+			"h": 14
 		},
-		"animation": true
-	},
-	"hop-north": {
-		"w": 35,
-		"h": 27,
-		"anchor": {
-			"x": 2,
-			"y": 11
+		"cube-idle": {
+			"w": 14,
+			"h": 14
 		},
-		"animation": true
-	},
-	"hop-east": {
-		"w": 35,
-		"h": 25,
-		"anchor": {
-			"x": 2,
-			"y": 2
+		"cube-off": {
+			"w": 14,
+			"h": 14
 		},
-		"animation": true
-	},
-	"hop-south": {
-		"w": 35,
-		"h": 25,
-		"anchor": {
-			"x": 19,
-			"y": 2
+		"talk-right": {
+			"w": 14,
+			"h": 14,
+			"animation": true
 		},
-		"animation": true
+		"talk-left": {
+			"w": 14,
+			"h": 14,
+			"animation": true
+		},
+		"hop-west": {
+			"w": 35,
+			"h": 27,
+			"anchor": {
+				"x": 19,
+				"y": 11
+			},
+			"animation": true
+		},
+		"hop-north": {
+			"w": 35,
+			"h": 27,
+			"anchor": {
+				"x": 2,
+				"y": 11
+			},
+			"animation": true
+		},
+		"hop-east": {
+			"w": 35,
+			"h": 25,
+			"anchor": {
+				"x": 2,
+				"y": 2
+			},
+			"animation": true
+		},
+		"hop-south": {
+			"w": 35,
+			"h": 25,
+			"anchor": {
+				"x": 19,
+				"y": 2
+			},
+			"animation": true
+		},
+		"brick-edge": {
+			"w": 32,
+			"h": 16
+		},
+		"grass-brick": {
+			"w": 32,
+			"h": 16
+		},
+		"flowers": {
+			"w": 32,
+			"h": 16
+		},
+		"grass": {
+			"w": 32,
+			"h": 16
+		},
+		"beacon": {
+			"w": 31,
+			"h": 56
+		}
 	},
-	"hopUpOffsets": {
-		"yFrames": [4, 6, 7, 8, 9],
-		"yValues": [-1, -1, -1, -2, -3]
+	"hopUpYOffsets": {
+		"frames": [4, 6, 7, 8, 9],
+		"values": [-1, -1, -1, -2, -3]
 	},
-	"hopDownOffsets": {
-		"yFrames": [4, 5, 6, 7, 8, 9],
-		"yValues": [1, 1, 2, 1, 2, 1]
+	"hopDownYOffsets": {
+		"frames": [4, 5, 6, 7, 8, 9],
+		"values": [1, 1, 2, 1, 2, 1]
 	},
-	"brick-edge": {
-		"w": 32,
-		"h": 16
-	},
-	"grass-brick": {
-		"w": 32,
-		"h": 16
-	},
-	"flowers": {
-		"w": 32,
-		"h": 16
-	},
-	"grass": {
-		"w": 32,
-		"h": 16
-	},
-	"beacon": {
-		"w": 31,
-		"h": 56
+	"hopZDepthOffsets": {
+		"frames": [6, 9],
+		"north": [-0.5, -0.5],
+		"west": [-0.5, -0.5],
+		"south": [0.5, 0.5],
+		"east": [0.5, 0.5]
 	}
 }

--- a/packages/webapp/source/art/sprite-config.json
+++ b/packages/webapp/source/art/sprite-config.json
@@ -57,6 +57,14 @@
 		},
 		"animation": true
 	},
+	"hopUpOffsets": {
+		"yFrames": [4, 6, 7, 8, 9],
+		"yValues": [-1, -1, -1, -2, -3]
+	},
+	"hopDownOffsets": {
+		"yFrames": [4, 5, 6, 7, 8, 9],
+		"yValues": [1, 1, 2, 1, 2, 1]
+	},
 	"brick-edge": {
 		"w": 32,
 		"h": 16

--- a/packages/webapp/source/components/Game/Common/ActorCell.ts
+++ b/packages/webapp/source/components/Game/Common/ActorCell.ts
@@ -1,0 +1,36 @@
+import { Cell3D, Cell3DOptions, Grid } from './Map'
+import { Entity } from 'ecsy'
+
+interface ActorCellOptions extends Cell3DOptions {
+	entity: Entity // Maybe we don't need this
+}
+
+export default class ActorCell extends Cell3D {
+	// private entity: Entity
+	private static hopZLevels: number[] = [0, 1, -1]
+
+	constructor(options: ActorCellOptions) {
+		super(options)
+		this.properties.solid = true
+		this.properties.platform = true
+		// this.entity = options.entity
+	}
+
+	getHopTarget(target: Grid): Grid | false {
+		if (this.getNeighbor({ x: 0, y: 0, z: 1 }).properties.solid) return false
+		let newTarget = { ...target }
+		for (let z of ActorCell.hopZLevels) {
+			newTarget.z = z
+			if (
+				!this.getNeighbor(newTarget).properties.solid &&
+				this.getNeighbor({ ...target, z: newTarget.z - 1 }).properties.platform
+			) {
+				return newTarget
+			}
+		}
+		return false
+	}
+	reserveTarget(target: Grid): void {
+		this.spread(target, { solid: true })
+	}
+}

--- a/packages/webapp/source/components/Game/Common/ActorCell.ts
+++ b/packages/webapp/source/components/Game/Common/ActorCell.ts
@@ -1,19 +1,12 @@
 import { Cell3D, Cell3DOptions, Grid } from './Map'
-import { Entity } from 'ecsy'
-
-interface ActorCellOptions extends Cell3DOptions {
-	entity: Entity // Maybe we don't need this
-}
 
 export default class ActorCell extends Cell3D {
-	// private entity: Entity
 	private static hopZLevels: number[] = [0, 1, -1]
 
-	constructor(options: ActorCellOptions) {
+	constructor(options: Cell3DOptions) {
 		super(options)
 		this.properties.solid = true
 		this.properties.platform = true
-		// this.entity = options.entity
 	}
 
 	getHopTarget(target: Grid): Grid | false {

--- a/packages/webapp/source/components/Game/Engine/Benchmark.ts
+++ b/packages/webapp/source/components/Game/Engine/Benchmark.ts
@@ -5,6 +5,18 @@ import Actor from './components/Actor'
 import Hop from './components/Hop'
 import { Grid } from '../Common/Map'
 
+export function createActor(world: World, grid: Grid): Entity {
+	return world
+		.createEntity()
+		.addComponent(Transform, grid)
+		.addComponent(Sprite, { texture: 'cube:0' })
+		.addComponent(Actor, {
+			userID: randomString([48, 57], 18),
+			username: randomString([32, 126], Math.floor(Math.random() * 12) + 3),
+			color: randomColor(),
+		})
+}
+
 export function addActors(world: World, count: number): Entity[] {
 	let entities: Entity[] = []
 	let gridPool = createGridPool(20, 20, 1)
@@ -13,15 +25,7 @@ export function addActors(world: World, count: number): Entity[] {
 			Math.floor(Math.random() * gridPool.length),
 			1
 		)[0]
-		let actorEntity = world
-			.createEntity()
-			.addComponent(Transform, grid)
-			.addComponent(Sprite, { texture: 'cube:0' })
-			.addComponent(Actor, {
-				userID: randomString([48, 57], 18),
-				username: randomString([32, 126], Math.floor(Math.random() * 12) + 3),
-				color: randomColor(),
-			})
+		let actorEntity = createActor(world, grid)
 		entities.push(actorEntity)
 	}
 	return entities
@@ -89,4 +93,30 @@ export function hopActor(actor: Entity, direction?: keyof typeof directions) {
 export function randomHop(): object {
 	let direction = Object.keys(directions)[Math.floor(Math.random() * 4)]
 	return directions[direction as keyof typeof directions]
+}
+
+export function hopTest(world: World) {
+	createActor(world, { x: 1, y: 0, z: 0 })
+	let hop2 = createActor(world, { x: 1, y: 0, z: 1 })
+	setTimeout(() => {
+		hopActor(hop2, 'west')
+	}, 1700)
+	createActor(world, { x: 0, y: 0, z: 0 })
+	createActor(world, { x: 0, y: -1, z: 0 })
+	createActor(world, { x: 0, y: -1, z: 1 })
+	hopActor(createActor(world, { x: 0, y: -1, z: 2 }), 'south')
+
+	createActor(world, { x: -1, y: 4, z: 0 })
+	createActor(world, { x: 0, y: 4, z: 0 })
+	createActor(world, { x: 0, y: 4, z: 1 })
+	hopActor(createActor(world, { x: 0, y: 4, z: 2 }), 'west')
+
+	for (let i = 0; i < 4; i++) {
+		let hopper = createActor(world, { x: 4, y: i, z: 0 })
+		setTimeout(() => {
+			setInterval(() => {
+				hopActor(hopper, 'south')
+			}, 1500)
+		}, i * 300)
+	}
 }

--- a/packages/webapp/source/components/Game/Engine/Benchmark.ts
+++ b/packages/webapp/source/components/Game/Engine/Benchmark.ts
@@ -3,17 +3,11 @@ import Transform from './components/Transform'
 import Sprite from './components/Sprite'
 import Actor from './components/Actor'
 import Hop from './components/Hop'
-import MapCell from './components/MapCell'
-
-interface Grid {
-	x: number
-	y: number
-	z: number
-}
+import { Grid } from '../Common/Map'
 
 export function addActors(world: World, count: number): Entity[] {
 	let entities: Entity[] = []
-	let gridPool = createGridPool(30, 30, 1)
+	let gridPool = createGridPool(20, 20, 1)
 	for (let i = 0; i < count; i++) {
 		let grid = gridPool.splice(
 			Math.floor(Math.random() * gridPool.length),
@@ -78,20 +72,18 @@ export function createGridPool(
 }
 
 const directions = {
-	east: { x: 1, y: 0, direction: 'east' },
-	west: { x: -1, y: 0, direction: 'west' },
-	south: { y: 1, x: 0, direction: 'south' },
-	north: { y: -1, x: 0, direction: 'north' },
+	east: { x: 1, y: 0, z: 0, direction: 'east' },
+	west: { x: -1, y: 0, z: 0, direction: 'west' },
+	south: { y: 1, x: 0, z: 0, direction: 'south' },
+	north: { y: -1, x: 0, z: 0, direction: 'north' },
 }
 
 export function hopActor(actor: Entity, direction?: keyof typeof directions) {
-	if (actor.hasComponent(Hop)) return
-	let hop = directions[direction as keyof typeof directions] || randomHop()
-	let { value: mapCell } = actor.getComponent(MapCell)!
-	if (!mapCell.getNeighbor(hop.x || 0, hop.y || 0, 0)) {
-		mapCell.spread(hop.x || 0, hop.y || 0, 0)
-		actor.addComponent(Hop, hop)
-	}
+	if (actor.hasComponent(Hop)) return // Already hopping
+	actor.addComponent(
+		Hop,
+		directions[direction as keyof typeof directions] || randomHop()
+	)
 }
 
 export function randomHop(): object {

--- a/packages/webapp/source/components/Game/Engine/systems/HopSystem.ts
+++ b/packages/webapp/source/components/Game/Engine/systems/HopSystem.ts
@@ -2,6 +2,12 @@ import { Attributes, System } from 'ecsy'
 import Hop from '../components/Hop'
 import Transform from '../components/Transform'
 import Sprite from '../components/Sprite'
+import MapCell from '../components/MapCell'
+import ActorCell from '../../Common/ActorCell'
+import {
+	hopUpOffsets,
+	hopDownOffsets,
+} from '../../../../art/sprite-config.json'
 
 let hopFrameCount: number
 
@@ -12,6 +18,23 @@ export default class HopSystem extends System {
 		hopFrameCount = this.animations['hop-east'].length
 	}
 	execute(_delta: number, _time: number) {
+		let added = this.queries.hopping.added
+		if (added) {
+			added.forEach((entity) => {
+				let hop = entity.getMutableComponent(Hop)!
+				let actorCell = entity.getComponent(MapCell)!.value as ActorCell
+				let target = actorCell.getHopTarget(hop)
+				if (target) {
+					actorCell.reserveTarget(target)
+					actorCell.properties.platform = false
+					Object.assign(hop, target)
+				} else {
+					faceSpriteToHop(entity.getMutableComponent(Sprite)!, hop)
+					entity.removeComponent(Hop)
+				}
+			})
+		}
+
 		let hopping = this.queries.hopping.results
 		for (let i = hopping.length - 1; i >= 0; i--) {
 			let entity = hopping[i]
@@ -22,23 +45,33 @@ export default class HopSystem extends System {
 				transform.x += hop.x
 				transform.y += hop.y
 				transform.z += hop.z
-				let sprite = entity.getMutableComponent(Sprite)!
-				if (hop.direction === 'east') sprite.texture = 'cube:0'
-				else if (hop.direction === 'south') sprite.texture = 'cube:1'
-				else sprite.texture = 'cube:2'
+				faceSpriteToHop(entity.getMutableComponent(Sprite)!, hop)
+				entity.getMutableComponent(MapCell)!.value.properties.platform = true
 				entity.removeComponent(Hop)
-				return
 			} else if (hop.progress === 0 || frame > hop.frame) {
 				hop.frame = frame
 				let sprite = entity.getMutableComponent(Sprite)!
 				sprite.texture = this.animations[`hop-${hop.direction}`][
 					hop.frame
 				].textureCacheIds[0]
+				if (hop.z !== 0) {
+					let offsets = hop.z > 0 ? hopUpOffsets : hopDownOffsets
+					let offsetIndex = offsets.yFrames.indexOf(hop.frame)
+					if (offsetIndex >= 0) sprite.y += offsets.yValues[offsetIndex]
+				}
 			}
 			hop.progress += 1 / (hopFrameCount * 2)
 		}
 	}
 }
 HopSystem.queries = {
-	hopping: { components: [Hop, Transform, Sprite] },
+	hopping: {
+		components: [Hop, Transform, Sprite, MapCell],
+		listen: { added: true },
+	},
+}
+function faceSpriteToHop(sprite: Sprite, hop: Hop) {
+	if (hop.direction === 'east') sprite.texture = 'cube:0'
+	else if (hop.direction === 'south') sprite.texture = 'cube:1'
+	else sprite.texture = 'cube:2'
 }

--- a/packages/webapp/source/components/Game/Engine/systems/MapSystem.ts
+++ b/packages/webapp/source/components/Game/Engine/systems/MapSystem.ts
@@ -13,12 +13,8 @@ export default class MapSystem extends System {
 	execute(_delta: number, _time: number) {
 		this.queries.added.results.forEach((entity) => {
 			let { x, y, z } = entity.getComponent(Transform)!
-			let cell
-			if (entity.hasComponent(Actor)) {
-				cell = new ActorCell({ map: this.map, x, y, z, entity })
-			} else {
-				cell = new Cell3D({ map: this.map, x, y, z })
-			}
+			let cellType = entity.hasComponent(Actor) ? ActorCell : Cell3D
+			let cell = new cellType({ map: this.map, x, y, z })
 			entity.addComponent(MapCell, { value: cell })
 			this.map.addCell(cell)
 		})

--- a/packages/webapp/source/components/Game/Game.ts
+++ b/packages/webapp/source/components/Game/Game.ts
@@ -19,6 +19,7 @@ export async function initGame(canvas: HTMLCanvasElement) {
 	console.log('Renderer created', renderer.app.stage)
 	const resources = new Resources()
 	await resources.load()
+	console.log('Resources loaded')
 	const engine: Engine = new Engine()
 	const map: Map3D = new Map3D()
 	engine.world.registerComponent(Sprite)

--- a/packages/webapp/source/components/Game/Renderer/Resources/Loader.ts
+++ b/packages/webapp/source/components/Game/Renderer/Resources/Loader.ts
@@ -17,7 +17,7 @@ function parseSheet(sheet: any, next: () => void) {
 				let layer = frameKey.split(':')[0]
 				let frame = res.data.frames![frameKey as keyof typeof res.data.frames]
 				let config: FrameConfig =
-					spriteConfig[layer as keyof typeof spriteConfig]
+					spriteConfig.frames[layer as keyof typeof spriteConfig.frames]
 				frame.sourceSize.w = config.w
 				frame.sourceSize.h = config.h
 				if (config.anchor) {


### PR DESCRIPTION
Actors can now hop on top of other actors.

A new cell type, `ActorCell` was created that extends `Cell3D` and has some actor-specific methods to help handle hopping.

Cells now have a `properties` field which (so far) has the tags `solid` and `platform`. These are used to invalidate hop targets. For example, an actor can't hop on top of a cell that is not tagged as a platform.

These cell tags are also used in the two new "static" cells, `FloorCell` and `EmptyCell`, which are returned from `Map3D.getXYZ` where appropriate (floor for `z < 0`, empty for an undefined grid). That means this method will always return a `Cell3D`, which makes checking the grid easier.

All map and cell methods that used to take `x, y, z` parameters now take a `Grid` parameter type, which is just an interface for `{ x, y, z }`. An interface was also created for `Cell3D` constructor options.

Hop components are now added without checking if they are valid. The hop is validated or removed in the hop system for entities with new hop components. If an actor fails to hop, it will face the direction it was trying to hop (like the old D-Zone).

Some new config properties were added to `sprite-config.json`. These handle shifting the `sprite.y` of specific frames while hopping up and down. They also handle offsetting the z-index while hopping. This may need tweaking later.

A new benchmark test was added to test hopping. It isn't used in the build but can be used during development.